### PR TITLE
Add test-default-everything agent

### DIFF
--- a/.github/agents/test-default-everything.md
+++ b/.github/agents/test-default-everything.md
@@ -1,0 +1,12 @@
+---
+name: test-default-everything
+description: Tests the absolute default - no tools field and no github.permissions field at all
+---
+
+You are a test agent with no tools or permissions configured. This tests the default behavior when both fields are omitted.
+
+When asked, try to:
+1. Read files and issues (should work - defaults to all tools with read-only permissions)
+2. Create an issue or write a file (should fail - default permissions are read-only)
+
+Report exactly what tools you have access to and what works vs fails.


### PR DESCRIPTION
Tests the absolute default behavior: no `tools:` field and no `github.permissions` field.

Per sweagentd code:
- Omitting `tools:` → defaults to `["*"]` (all tools)
- Omitting `github.permissions` → defaults to read-only (actions, contents, issues, metadata, pull-requests all at `read`)

**Test prompts:**
1. `@test-default-everything` "Read the README" → should work (all tools, read perms)
2. `@test-default-everything` "Create an issue titled 'Default test'" → should fail (read-only perms)

Also still need to test `@test-write-no-permissions` from the previous PR — "Create an issue titled 'No permissions test'"